### PR TITLE
More launch arguments, fixed scan duration

### DIFF
--- a/launch/os1.launch
+++ b/launch/os1.launch
@@ -3,15 +3,17 @@
 
 <launch>
 
-  <arg name="lidar_address" default="192.168.2.70" doc="hostname or IP address in dotted decimal form of the Ouster sensor"/>
-  <arg name="pc_address" default="192.168.2.1" doc="hostname or IP address of the computer (PC) where the sensor will send data packets"/>
+  <arg name="lidar_address" default="192.168.0.100" doc="hostname or IP address in dotted decimal form of the Ouster sensor"/>
+  <arg name="pc_address" default="192.168.0.1" doc="hostname or IP address of the computer (PC) where the sensor will send data packets"/>
   <arg name="lidar_port" default="7502" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="7503" doc="port to which the sensor should send imu data"/>
   <arg name="replay" default="false" doc="when true, the node will listen on ~/lidar_packets and ~/imu_packets for data instead of attempting to connect to a sensor"/>
   <arg name="scan_dur_ns" default="100000000" doc="nanoseconds to batch lidar packets before publishing a cloud"/>
   <arg name="mode_xyzir" default="true" doc="Point cloud mode, either XYZIR (velodyne compatible) on true, or the default for PointOS1 on false"/>
   <arg name="lidar_frame_name" default="velodyne" doc="Frame name for lidar output message"/>
+  <arg name="lidar_topic_name" default="/points_raw" doc="Topic name for lidar output message"/>
   <arg name="imu_frame_name" default="imu" doc="Frame name for IMU output message"/>
+  <arg name="imu_topic_name" default="/imu_raw" doc="Topic name for IMU output message"/>
   <arg name="operation_mode" default="1" doc="operation mode (hor. res. and scan rate)"/>
   <arg name="pulse_mode" default="0" doc="Laser pulse width"/>
   <arg name="window_rejection" default="true" doc="Window rejection enable"/>
@@ -23,8 +25,8 @@
     <param name="os1_imu_port" value="$(arg imu_port)"/>
     <param name="replay" value="$(arg replay)"/>
     <param name="scan_dur_ns" value="$(arg scan_dur_ns)"/>
-    <param name="points_topic_name" value="/points_raw"/>
-    <param name="imu_topic_name" value="/imu_raw"/>
+    <param name="points_topic_name" value="$(arg lidar_topic_name)"/>
+    <param name="imu_topic_name" value="$(arg imu_topic_name)"/>
     <param name="lidar_frame_name" value="$(arg lidar_frame_name)"/>
     <param name="imu_frame_name" value="$(arg imu_frame_name)"/>
     <param name="mode_xyzir" value="$(arg mode_xyzir)"/>

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ where `<HOSTNAME>` is your computer's assigned hostname, `<INTERFACENAME>` is th
 ```
 
 ##Todo
-- [x] Velodyne compatibility mode
-- [ ] Configure active sensor parameters from driver code, in particular `lidar_mode`
-
+- [x] Velodyne compatibility mode.
+- [x] Configure active sensor parameters from driver code, in particular `lidar_mode`.
+- [ ] Fix `replay` option currently not working.
+- [ ] Verify the sensor operation information and attempt software reset on error condition, and current parameter values to avoid unnecessary rewrites/reinitialization.

--- a/src/os1_node.cpp
+++ b/src/os1_node.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
     auto queue_size = 10;
     if ((ouster::OS1::OperationMode)operation_mode == ouster::OS1::MODE_512x20 || (ouster::OS1::OperationMode)operation_mode == ouster::OS1::MODE_1024x20) {
     	queue_size = 20;
+    	scan_dur = scan_dur / 2; //scan duration should be smaller at faster frame rates
     }
     //----------------
 


### PR DESCRIPTION
Fixed launch file to deal with some hidden parameters, fixed `readme.md` to update the *TODO*, fixed `os1_node.cpp` to reduce by half the scan duration variable in case of 20Hz operation.