### PR TITLE
New pointcloud mode formats added

### DIFF
--- a/include/ouster_ros/os1_ros.h
+++ b/include/ouster_ros/os1_ros.h
@@ -21,7 +21,11 @@ namespace ouster_ros {
 namespace OS1 {
 
 using CloudOS1 = pcl::PointCloud<PointOS1>;
-using CloudOS1XYZIR = pcl::PointCloud<PointOS1XYZIR>;
+using CloudOS1XYZ = pcl::PointCloud<pcl::PointXYZ>;
+using CloudOS1XYZI = pcl::PointCloud<pcl::PointXYZI>;
+using CloudOS1XYZIR = pcl::PointCloud<PointXYZIR>;
+using CloudOS1XYZIF = pcl::PointCloud<PointXYZIF>;
+using CloudOS1XYZIFN = pcl::PointCloud<PointXYZIFN>;
 using ns = std::chrono::nanoseconds;
 
 /**
@@ -116,18 +120,35 @@ std::function<void(const PacketMsg&)> batch_packets(
 
 /**
  * Define the pointcloud type to use
- * @param mode_xyzir to publish PointXYZIR point cloud type (when true), or the native PointOS1 (when false)
- *
- * @note This function was added to support velodyne compatible mode for Autoware.
+ * @param mode_xyzir specifies the point cloud type to publish
+ * supported values: NATIVE, XYZ, XYZI, XYZIR, XYZIF, XYZIFN
  */
-void set_point_mode(bool mode_xyzir);
+void set_point_mode(std::string mode_xyzir);
+
+/**
+ * Converts the OS1 native point format to XYZ
+ */
+void convert2XYZ(const CloudOS1& in, CloudOS1XYZ& out);
+
+/**
+ * Converts the OS1 native point format to XYZI
+ */
+void convert2XYZI(const CloudOS1& in, CloudOS1XYZI& out);
 
 /**
  * Converts the OS1 native point format to XYZIR (Velodyne like) 
- * 
- * @note This function was added to support velodyne compatible mode for Autoware.
  */
 void convert2XYZIR(const CloudOS1& in, CloudOS1XYZIR& out);
+
+/**
+ * Converts the OS1 native point format to XYZIF (with intensity and reflectivity) 
+ */
+void convert2XYZIF(const CloudOS1& in, CloudOS1XYZIF& out);
+
+/**
+ * Converts the OS1 native point format to XYZIFN (with intensity and reflectivity and ambient noise)
+ */
+void convert2XYZIFN(const CloudOS1& in, CloudOS1XYZIFN& out);
 
 }
 }

--- a/include/ouster_ros/point_os1.h
+++ b/include/ouster_ros/point_os1.h
@@ -8,18 +8,35 @@ namespace OS1 {
 struct EIGEN_ALIGN16 PointOS1 {
     PCL_ADD_POINT4D;
     float t;
-    uint16_t reflectivity;
     uint16_t intensity;
+    uint16_t reflectivity;
+    uint16_t noise;
     uint8_t ring;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-struct EIGEN_ALIGN16 PointOS1XYZIR {
+struct EIGEN_ALIGN16 PointXYZIR {
     PCL_ADD_POINT4D;                    // quad-word XYZ
     float    intensity;                 ///< laser intensity reading
     uint16_t ring;                      ///< laser ring number
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // ensure proper alignment
 };
+
+struct EIGEN_ALIGN16 PointXYZIF {
+    PCL_ADD_POINT4D;
+    uint16_t intensity;
+    uint16_t reflectivity;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct EIGEN_ALIGN16 PointXYZIFN {
+    PCL_ADD_POINT4D;
+    uint16_t intensity;
+    uint16_t reflectivity;
+    uint16_t noise;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
 }
 }
 
@@ -28,16 +45,35 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointOS1,
     (float, y, y)
     (float, z, z)
     (float, t, t)
-    (uint16_t, reflectivity, reflectivity)
     (uint16_t, intensity, intensity)
+    (uint16_t, reflectivity, reflectivity)
     (uint8_t, ring, ring)
 )
 
-POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointOS1XYZIR,
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointXYZIR,
     (float, x, x)
     (float, y, y)
     (float, z, z)
     (float, intensity, intensity)
     (uint16_t, ring, ring)
 )
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointXYZIF,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (uint16_t, intensity, intensity)
+    (uint16_t, reflectivity, reflectivity)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointXYZIFN,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (uint16_t, intensity, intensity)
+    (uint16_t, reflectivity, reflectivity)
+    (uint16_t, noise, noise)
+)
+
+
 

--- a/launch/os1.launch
+++ b/launch/os1.launch
@@ -9,7 +9,7 @@
   <arg name="imu_port" default="7503" doc="port to which the sensor should send imu data"/>
   <arg name="replay" default="false" doc="when true, the node will listen on ~/lidar_packets and ~/imu_packets for data instead of attempting to connect to a sensor"/>
   <arg name="scan_dur_ns" default="100000000" doc="nanoseconds to batch lidar packets before publishing a cloud"/>
-  <arg name="pointcloud_mode" default="XYZIR" doc="Point cloud mode, supported modes: NATIVE, XYZ, XYZI, XYZIR, XYZIF, XYZIFN. NATIVE is XYZIFN + timestamp channel"/>
+  <arg name="pointcloud_mode" default="XYZIR" doc="Point cloud mode, supported modes: NATIVE, XYZ, XYZI, XYZIR, XYZIF, XYZIFN (I=intensity, R=ring, F=reflectivity, N=ambient noise). NATIVE is XYZIRFt where t=point timestamp."/>
   <arg name="lidar_frame_name" default="velodyne" doc="Frame name for lidar output message"/>
   <arg name="lidar_topic_name" default="/points_raw" doc="Topic name for lidar output message"/>
   <arg name="imu_frame_name" default="imu" doc="Frame name for IMU output message"/>

--- a/launch/os1.launch
+++ b/launch/os1.launch
@@ -3,15 +3,17 @@
 
 <launch>
 
-  <arg name="lidar_address" default="192.168.2.70" doc="hostname or IP address in dotted decimal form of the Ouster sensor"/>
-  <arg name="pc_address" default="192.168.2.1" doc="hostname or IP address of the computer (PC) where the sensor will send data packets"/>
+  <arg name="lidar_address" default="192.168.0.100" doc="hostname or IP address in dotted decimal form of the Ouster sensor"/>
+  <arg name="pc_address" default="192.168.0.1" doc="hostname or IP address of the computer (PC) where the sensor will send data packets"/>
   <arg name="lidar_port" default="7502" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="7503" doc="port to which the sensor should send imu data"/>
   <arg name="replay" default="false" doc="when true, the node will listen on ~/lidar_packets and ~/imu_packets for data instead of attempting to connect to a sensor"/>
   <arg name="scan_dur_ns" default="100000000" doc="nanoseconds to batch lidar packets before publishing a cloud"/>
-  <arg name="mode_xyzir" default="true" doc="Point cloud mode, either XYZIR (velodyne compatible) on true, or the default for PointOS1 on false"/>
+  <arg name="pointcloud_mode" default="XYZIR" doc="Point cloud mode, supported modes: NATIVE, XYZ, XYZI, XYZIR, XYZIF, XYZIFN. NATIVE is XYZIFN + timestamp channel"/>
   <arg name="lidar_frame_name" default="velodyne" doc="Frame name for lidar output message"/>
+  <arg name="lidar_topic_name" default="/points_raw" doc="Topic name for lidar output message"/>
   <arg name="imu_frame_name" default="imu" doc="Frame name for IMU output message"/>
+  <arg name="imu_topic_name" default="/imu_raw" doc="Topic name for IMU output message"/>
   <arg name="operation_mode" default="1" doc="operation mode (hor. res. and scan rate)"/>
   <arg name="pulse_mode" default="0" doc="Laser pulse width"/>
   <arg name="window_rejection" default="true" doc="Window rejection enable"/>
@@ -23,11 +25,11 @@
     <param name="os1_imu_port" value="$(arg imu_port)"/>
     <param name="replay" value="$(arg replay)"/>
     <param name="scan_dur_ns" value="$(arg scan_dur_ns)"/>
-    <param name="points_topic_name" value="/points_raw"/>
-    <param name="imu_topic_name" value="/imu_raw"/>
+    <param name="points_topic_name" value="$(arg lidar_topic_name)"/>
+    <param name="imu_topic_name" value="$(arg imu_topic_name)"/>
     <param name="lidar_frame_name" value="$(arg lidar_frame_name)"/>
     <param name="imu_frame_name" value="$(arg imu_frame_name)"/>
-    <param name="mode_xyzir" value="$(arg mode_xyzir)"/>
+    <param name="pointcloud_mode" value="$(arg pointcloud_mode)"/>
     <param name="operation_mode" value="$(arg operation_mode)"/>
     <param name="pulse_mode" value="$(arg pulse_mode)"/>
     <param name="window_rejection" value="$(arg window_rejection)"/>

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ where `<HOSTNAME>` is your computer's assigned hostname, `<INTERFACENAME>` is th
 ```
 
 ##Todo
-- [x] Velodyne compatibility mode
-- [ ] Configure active sensor parameters from driver code, in particular `lidar_mode`
-
+- [x] Velodyne compatibility mode.
+- [x] Configure active sensor parameters from driver code, in particular `lidar_mode`.
+- [ ] Fix `replay` option currently not working.
+- [ ] Verify the sensor operation information and attempt software reset on error condition, and current parameter values to avoid unnecessary rewrites/reinitialization.

--- a/src/os1_node.cpp
+++ b/src/os1_node.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     auto imu_topic_name = nh.param("imu_topic_name", std::string("/imu_raw"));
     auto lidar_frame_name = nh.param("lidar_frame_name", std::string("/os1"));
     auto imu_frame_name = nh.param("imu_frame_name", std::string("/os1_imu"));
-    auto mode_xyzir = nh.param("mode_xyzir", false);
+    auto pointcloud_mode = nh.param("pointcloud_mode", std::string("NATIVE"));
     auto operation_mode = nh.param("operation_mode", 1);
     auto pulse_mode = nh.param("pulse_mode", 0);
     auto window_rejection = nh.param("window_rejection", true);
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
      * @note Added to support Velodyne compatible pointcloud format for Autoware
      */
     //defines the pointcloud mode
-    ouster_ros::OS1::set_point_mode(mode_xyzir);
+    ouster_ros::OS1::set_point_mode(pointcloud_mode);
     //----------------
     /**
      * @note Added to support advanced mode parameters configuration for Autoware
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
     auto queue_size = 10;
     if ((ouster::OS1::OperationMode)operation_mode == ouster::OS1::MODE_512x20 || (ouster::OS1::OperationMode)operation_mode == ouster::OS1::MODE_1024x20) {
     	queue_size = 20;
+    	scan_dur = scan_dur / 2; //scan duration should be smaller at faster frame rates
     }
     //----------------
 


### PR DESCRIPTION
removed the old boolean `pointcloud_mode_xyzir` parameter (designed to match Velodyne's pointcloud mode) and replaced with a more general way to specify the desired pointcloud format, several options added including Ouster's native pointcloud format.