### PR TITLE
Add timestamping_mode parameter

### DIFF
--- a/include/ouster/os1.h
+++ b/include/ouster/os1.h
@@ -72,6 +72,16 @@ typedef enum {
 using OperationMode = operation_mode_t;
 
 /**
+ * Timestamp modes supported by the OS1 LiDAR
+ */
+typedef enum {
+      TIME_FROM_INTERNAL_OSC=0,
+      TIME_FROM_PTP_1588=1,
+      TIME_FROM_SYNC_PULSE_IN=2,
+} timestamp_mode_t;
+using TimestampMode = timestamp_mode_t;
+
+/**
  * Laser pulse modes supported by the OS1 LiDAR
  */
 typedef enum {
@@ -86,7 +96,8 @@ using PulseMode = pulse_mode_t;
  * @param window_rejection to reject short range data (true), or to accept short range data (false)
  * @note This function was added to configure advanced operation modes for Autoware
  */
-void set_advanced_params(std::string operation_mode_str, std::string pulse_mode_str, bool window_rejection);
+void set_advanced_params(std::string operation_mode_str, std::string timestamp_mode_str,
+                         std::string pulse_mode_str, bool window_rejection);
 
 }
 }

--- a/launch/os1.launch
+++ b/launch/os1.launch
@@ -15,6 +15,7 @@
   <arg name="imu_frame_name" default="imu" doc="Frame name for IMU output message"/>
   <arg name="imu_topic_name" default="/imu_raw" doc="Topic name for IMU output message"/>
   <arg name="operation_mode" default="1024x10" doc="Supported operation modes: 512x10, 1024x10, 2048x10, 512x20, 1024x20 (horizontal resolution x scan rate)"/>
+  <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="Supported timestamp modes: TIME_FROM_INTERNAL_OSC, TIME_FROM_PTP_1588, TIME_FROM_SYNC_PULSE_IN"/>
   <arg name="pulse_mode" default="STANDARD" doc="Laser pulse width, available modes: STANDARD and NARROW"/>
   <arg name="window_rejection" default="true" doc="Window (short range) rejection enable"/>
 
@@ -31,6 +32,7 @@
     <param name="imu_frame_name" value="$(arg imu_frame_name)"/>
     <param name="pointcloud_mode" value="$(arg pointcloud_mode)"/>
     <param name="operation_mode" value="$(arg operation_mode)"/>
+    <param name="timestamp_mode" value="$(arg timestamp_mode)"/>
     <param name="pulse_mode" value="$(arg pulse_mode)"/>
     <param name="window_rejection" value="$(arg window_rejection)"/>
   </node>

--- a/src/os1.cpp
+++ b/src/os1.cpp
@@ -348,6 +348,7 @@ void set_advanced_params(std::string operation_mode_str, std::string timestamp_m
        _operation_mode = ouster::OS1::MODE_1024x20;
    } else {
    	   std::cout << "Selected operation mode " << _operation_mode_str << " is invalid, using default mode \"1024x10\"" << std::endl;
+       _operation_mode_str = "1024x10";
    }
 
     _timestamp_mode = ouster::OS1::TIME_FROM_INTERNAL_OSC;
@@ -359,6 +360,7 @@ void set_advanced_params(std::string operation_mode_str, std::string timestamp_m
         _timestamp_mode = ouster::OS1::TIME_FROM_SYNC_PULSE_IN;
     } else {
         std::cout << "Selected timestamp mode " << _timestamp_mode_str << " is invalid, using default mode \"TIME_FROM_INTERNAL_OSC\"" << std::endl;
+        _timestamp_mode_str = "TIME_FROM_INTERNAL_OSC";
     }
 
    _pulse_mode = ouster::OS1::PULSE_STANDARD;
@@ -368,6 +370,7 @@ void set_advanced_params(std::string operation_mode_str, std::string timestamp_m
    	   _pulse_mode = ouster::OS1::PULSE_NARROW;
    } else {
    	   std::cout << "Selected pulse mode " << _pulse_mode_str << " is invalid, using default mode \"STANDARD\"" << std::endl;
+       _pulse_mode_str = "STANDARD";
    }
 
    _window_rejection_str = ((_window_rejection) ? std::string("1") : std::string("0"));

--- a/src/os1_ros.cpp
+++ b/src/os1_ros.cpp
@@ -108,11 +108,7 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const CloudOS1& cloud, ns timestamp,
     }
 
     msg.header.frame_id = frame;
-    /**
-     * @note Changed timestamp from LiDAR to ROS time for Autoware operation
-     */
-    //msg.header.stamp.fromNSec(timestamp.count()); //<-- original code of OS1 driver
-    msg.header.stamp = ros::Time::now();  //<-- prefered time mode in Autoware
+    msg.header.stamp.fromNSec(timestamp.count());
     return msg;
 }
 
@@ -193,7 +189,7 @@ std::function<void(const PacketMsg&)> batch_packets(
 
         auto batch_dur = packet_ts - scan_ts;
         if (batch_dur >= scan_dur || batch_dur < ns(0)) {
-            f(scan_ts, *cloud);
+            f(packet_ts, *cloud);
 
             cloud->clear();
             scan_ts = ns(-1L);


### PR DESCRIPTION
Added support for setting the timestamping mode. Supported timestamp modes on OS-1: TIME_FROM_INTERNAL_OSC (default), TIME_FROM_PTP_1588, and TIME_FROM_SYNC_PULSE_IN. The default is left at TIME_FROM_INTERNAL_OSC so nothing changes if the parameter is not defined.

If TIME_FROM_PTP_1588 is used the pointcloud message timestamp is used directly from the lidar instead of ros::Time::now().